### PR TITLE
Disable execution of PHP on old revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ Dokuwiki plugin to restrict php inclusion to pages by namespace or name.
 
 Overrides the current PHP setting, which enables PHP on all pages.
 
-Enable PHP by namespace ("fred:"), page ("fred:derf") and page-prefix ("fred:php*). You can then use the ACL to determine what users have the ability to edit PHP pages.
+Enable PHP by namespace ("fred:"), page ("fred:derf") and page-prefix ("fred:php*).
+You can then use the ACL to determine what users have the ability to edit PHP pages.
 
 You can also disable "view source" on PHP pages (recommended).
+
+PHP is also disabled on old revision pages.

--- a/action/action.php
+++ b/action/action.php
@@ -22,11 +22,11 @@ class action_plugin_phprestrict_action extends DokuWiki_Action_Plugin {
 	 */
 
 	public function register(Doku_Event_Handler $controller) {
-		
+
 		// Future feature: To kill PHP in non-enabled pages, will need to hook IO_WIKIPAGE_READ
-				
+
 		$controller->register_hook('DOKUWIKI_STARTED', 'BEFORE', $this, 'handle_action');
-		
+
 	}
 
 	/**
@@ -34,66 +34,74 @@ class action_plugin_phprestrict_action extends DokuWiki_Action_Plugin {
 	 */
 
 	public function handle_action(Doku_Event &$event, $param) {
-	
+
 		global $conf;
 		global $INFO;
-		
+		global $REV;
+
 		// default to php being disabled on all pages
 
 		$conf['phpok'] = 0;
-		
+
+		// php is NEVER OK on revision pages
+
+		if ($REV) {
+			return;
+
+		}
+
 		// check for path match and enable PHP if found
 
 		$paths = explode(',',
 						 str_replace(array("\r\n","\r","\n"),',',
 									 $this->getConf('paths')
 						));
-		
+
 		$id = $INFO['id'];
-		
+
 		foreach ($paths as $path) {
-					
+
 			switch (substr($path,-1)) {
-			
+
 				case false:		// empty string
-				
+
 					continue;	// try next path
-					
+
 				case ':':
-				
+
 					$phpok = (strpos($id,$path) === 0);
 					break;
-					
+
 				case '*':
-				
+
 					$phpok = (strpos($id,substr($path,0,-1)) === 0);
 					break;
-					
+
 				default:
-				
+
 					$phpok = ($id === $path);
 					break;
-					
+
 			}
-				
+
 			if ($phpok) {
-			
+
 				$conf['phpok'] = 1;
-				
+
 				// source display/export/revisions can be disabled on potential PHP pages
-				
+
 				if ($this->getConf('hide') === 1) {
 					if (strpos($conf['disableactions'],'source') === false) $conf['disableactions'] .= ',source';
 					if (strpos($conf['disableactions'],'export_raw') === false) $conf['disableactions'] .= ',export_raw';
 					if (strpos($conf['disableactions'],'revisions') === false) $conf['disableactions'] .= ',revisions';
 				}
-				
+
 				return;
-				
-			}		
-		   
+
+			}
+
 		}
-		
+
 		// fall through to default of no php!
 
 	}

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   phprestrict
 author Robert Woodhead
 email  trebor@animeigo.com
-date   2016-06-07
+date   2016-11-23
 name   phprestrict plugin
 desc   Restricts PHP by namespace / page
 url    https://www.dokuwiki.org/plugin:phprestrict


### PR DESCRIPTION
If the revision url was known, a user could execute an earlier version
of a PHP script. This is now disabled.